### PR TITLE
removing the absolutely positioning on the page content

### DIFF
--- a/teacher-resources/css/simple-sidebar.css
+++ b/teacher-resources/css/simple-sidebar.css
@@ -43,7 +43,6 @@
 
 #page-content-wrapper {
     width: 100%;
-    position: absolute;
     padding: 15px;
 }
 


### PR DESCRIPTION
This should do the trick, but I haven't tested it on every page.