### PR TITLE
Workaround for duplicate key in hash literal

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -263,10 +263,9 @@ jobs:
 
                 echo "Cleaning up blob storage"
                 $routes = (az network front-door routing-rule list -f missionbit-dev -g www-dev | ConvertFrom-Json)
-                $validPrefix = @{
-                  "$env:Build_SourceVersion/" = $true;
-                  "$(oldPrefix)" = $true
-                }
+                $validPrefix = @{ "$env:Build_SourceVersion/" = $true }
+                $validPrefix["$(oldPrefix)"] = $true
+
                 $routes.routeConfiguration.customForwardingPath.where({ $_ }).ForEach({
                   $validPrefix[$_.TrimStart("/")] = $true
                 })


### PR DESCRIPTION
https://dev.azure.com/missionbit/www.missionbit.org/_build/results?buildId=830&view=logs&jobId=5fc6af58-8629-564e-a7c2-37d01c4deb6f&j=5fc6af58-8629-564e-a7c2-37d01c4deb6f&t=e011885c-1710-5c63-6414-a2d9cdddbc61

```
2020-02-07T00:25:09.1345644Z Duplicate keys '0ad576b4addc23c1088f6dd45e5bcd69341a93ed...' are not allowed in hash literals.
2020-02-07T00:25:09.1346576Z At D:\a\_temp\azureclitaskscript1581035054828_inlinescript.ps1:67 char:3
2020-02-07T00:25:09.1346875Z +   "0ad576b4addc23c1088f6dd45e5bcd69341a93ed/" = $true
2020-02-07T00:25:09.1347152Z +   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2020-02-07T00:25:09.1347405Z     + CategoryInfo          : InvalidOperation: (System.Collections.Hashtable:Hashtable) [], ParentContainsErrorRecord 
2020-02-07T00:25:09.1347666Z    Exception
2020-02-07T00:25:09.1347889Z     + FullyQualifiedErrorId : DuplicateKeyInHashLiteral
2020-02-07T00:25:09.1348115Z  
```